### PR TITLE
feat: 헤더 - 프로필  클릭 시 네비 바 유지

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -48,6 +48,10 @@ const HeaderLoggedIn = ( { isLoggedIn, handleLogout } ) => {
     dispatch(setActiveMenu('전체 글 보기'));
   };
 
+  const handleProfileClick = () => {
+    dispatch(setActiveMenu('내가 쓴 글'));
+  }
+
   useEffect(() => {
 
     if (accessToken) {
@@ -71,7 +75,7 @@ const HeaderLoggedIn = ( { isLoggedIn, handleLogout } ) => {
           <FontAwesomeIcon icon={faMagnifyingGlass} />
         </div>
         <div className='header_bar_user'>
-          <Link to='/mypage/main' className="header_profile">
+          <Link to='/mypage/main' className="header_profile" onClick={handleProfileClick}>
             <img className="header_user_picture" src={require("../assets/user_shadow.png")} alt="user profile" />
             <div className="header_user_name">{userName} 님</div>
           </Link>


### PR DESCRIPTION
## 작업 개요
로그인 상태 헤더 바에서 프로필 클릭 시 네비 바 '내 글 보기'를 유지하는 로직입니다.
## 작업 상세
```javascript
  const handleProfileClick = () => {
    dispatch(setActiveMenu('내가 쓴 글'));
  }

 // return문 내
  <Link to='/mypage/main' className="header_profile" onClick={handleProfileClick}>
    <img className="header_user_picture" src={require("../assets/user_shadow.png")} alt="user profile" />
    <div className="header_user_name">{userName} 님</div>
  </Link>
```
