### PR TITLE
Feat : PostList 리팩토링

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -14,19 +14,22 @@
     "plugin:import/recommended",
     "prettier"
   ],
-  "plugins": [
-    "react",
-    "react-hooks",
-    "jsx-a11y",
-    "import"
-  ],
+  "plugins": ["react", "react-hooks", "jsx-a11y", "import"],
   "rules": {
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "import/no-unresolved": [2, { "commonjs": true, "amd": true }],
+    "import/extensions": [2, "ignorePackages"],
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    }
   },
   "settings": {
     "import/resolver": {
       "node": {
-        "paths": ["src"] // src 폴더를 모듈 경로로 추가
+        "paths": ["src"], // src 폴더를 모듈 경로로 추가
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,26 +20,24 @@ import MyPageInfo from './pages/MyPageInfo.jsx';
 import MyPost from 'pages/MyPost.jsx';
 
 function App() {
-  
   return (
     <div className="App">
-      
       <Router>
         <Header />
         <Routes>
-          <Route path="/" element={<AllBoardPage/>} />
-          <Route path="/login" element={<Login/>} />
-          <Route path="/signup" element={<SignUpPage/>} />
-          <Route path="/posts/write" element={<EditerPage/>} />
+          <Route path="/" element={<AllBoardPage />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<SignUpPage />} />
+          <Route path="/posts/write" element={<EditerPage />} />
 
-          <Route path="/free" element={<FreeBoardPage/>} />
-          <Route path="/free/:postId/:userId/:voteId" element={<FreeDetailPage />} />
-          <Route path="/auth" element={<AuthBoardPage/>} />
-          <Route path="/auth/:postId/:userId" element={<AuthDetailPage/>} />
-          <Route path="/env" element={<EnvBoardPage/>} />
+          <Route path="/free" element={<FreeBoardPage />} />
+          <Route path="/free/:postId/:userId" element={<FreeDetailPage />} />
+          <Route path="/auth" element={<AuthBoardPage />} />
+          <Route path="/auth/:postId/:userId" element={<AuthDetailPage />} />
+          <Route path="/env" element={<EnvBoardPage />} />
 
           <Route path="/mypage/main" element={<MyPageMain />} />
-          <Route path="/mypage/info" element={<MyPageInfo/>} />
+          <Route path="/mypage/info" element={<MyPageInfo />} />
           <Route path="mypage/posts/:postId" element={<MyPost />} />
         </Routes>
       </Router>

--- a/client/src/components/AuthPostList.jsx
+++ b/client/src/components/AuthPostList.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/AuthPostList.css';
 import { getAuthPosts } from 'api/api.js';
+import { Interface } from 'readline';
 
 const AuthPostList = () => {
   const [allAuthPosts, setAllAuthPosts] = useState([]);
@@ -10,16 +11,26 @@ const AuthPostList = () => {
   const itemsPerPage = 6;
   const maxPagesToShow = 5; // 한 번에 보여줄 최대 페이지 수
 
+  // interface AuthPost {
+  //   createdAt: string;
+  //   postId: number;
+  //   title: string;
+  //   userId: number;
+  //   body: string;
+  //   open: boolean;
+  //   imageUrls: string;
+  // }
+
   useEffect(() => {
     getAuthPosts()
-      .then((res)=> {
+      .then(res => {
         const sortedData = res.data.sort((a, b) => {
           return new Date(b.createdAt) - new Date(a.createdAt);
         });
         setAllAuthPosts(sortedData);
         setVisibleAuthPosts(sortedData.slice(0, 6));
       })
-      .catch((error) => console.error('Error:', error));
+      .catch(error => console.error('Error:', error));
   }, []);
 
   // 페이지를 변경할 때 visibleAuthPosts 업데이트
@@ -36,7 +47,7 @@ const AuthPostList = () => {
   };
 
   // 페이지 번호를 클릭했을 때 호출되는 함수
-  const handlePageClick = (pageNumber) => {
+  const handlePageClick = pageNumber => {
     setCurrentPage(pageNumber);
   };
 
@@ -76,31 +87,33 @@ const AuthPostList = () => {
       <div className="auth_post_grid">
         {visibleAuthPosts.map((post, index) => (
           <Link
-          to={`/auth/${post.postId}/${post.userId}`} // 경로 설정
-          key={post.postId}
-          className="auth_post_item_container"
-          >
+            to={`/auth/${post.postId}/${post.userId}`} // 경로 설정
+            key={post.postId}
+            className="auth_post_item_container">
             <img src={post.imageUrl} alt={`${post.postId}`} />
           </Link>
         ))}
       </div>
       <div className="pagination">
-        {!isPrevButtonDisabled && visibleAuthPosts.length > 0 && <button onClick={() => handlePageClick(1)}>&lt;&lt;</button>}
-        {!isPrevButtonDisabled && visibleAuthPosts.length > 0 && <button onClick={() => handlePageClick(currentPage - 1)}>&lt;</button>}
-        {getPageNumbers().map((pageNumber) => (
+        {!isPrevButtonDisabled && visibleAuthPosts.length > 0 && (
+          <button onClick={() => handlePageClick(1)}>&lt;&lt;</button>
+        )}
+        {!isPrevButtonDisabled && visibleAuthPosts.length > 0 && (
+          <button onClick={() => handlePageClick(currentPage - 1)}>&lt;</button>
+        )}
+        {getPageNumbers().map(pageNumber => (
           <button
             key={pageNumber}
             onClick={() => handlePageClick(pageNumber)}
-            className={currentPage === pageNumber ? 'active' : ''}
-          >
+            className={currentPage === pageNumber ? 'active' : ''}>
             {pageNumber}
           </button>
         ))}
-        {!isNextButtonDisabled && visibleAuthPosts.length > 0 && <button onClick={() => handlePageClick(currentPage + 1)}>&gt;</button>}
         {!isNextButtonDisabled && visibleAuthPosts.length > 0 && (
-          <button onClick={() => handlePageClick(Math.ceil(allAuthPosts.length / itemsPerPage))}>
-            &gt;&gt;
-          </button>
+          <button onClick={() => handlePageClick(currentPage + 1)}>&gt;</button>
+        )}
+        {!isNextButtonDisabled && visibleAuthPosts.length > 0 && (
+          <button onClick={() => handlePageClick(Math.ceil(allAuthPosts.length / itemsPerPage))}>&gt;&gt;</button>
         )}
       </div>
     </>

--- a/client/src/components/PostList.tsx
+++ b/client/src/components/PostList.tsx
@@ -3,41 +3,41 @@ import '../styles/PostList.css';
 import { Link } from 'react-router-dom';
 import { getAllPosts, getAlltypePosts } from 'api/api.js';
 import PropTypes from 'prop-types';
+import { Post, PostListProps } from '../types/types';
 
-const PostList = (props) => {
-  const [allPosts, setAllPosts] = useState([]);
-  const [visiblePosts, setVisiblePosts] = useState([]);
-  const [loading, setLoading] = useState(false);
+const PostList: React.FC<PostListProps> = props => {
+  const [allPosts, setAllPosts] = useState<Post[]>([]);
+  const [visiblePosts, setVisiblePosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
 
-  const intersectionRef = useRef(null);
+  const intersectionRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (props.type === 'all') {
       getAllPosts() //모든 게시글 가져오기
-        .then((res) => {
-          const sortedData = res.data.sort((a, b) => {
-            return new Date(b.createdAt) - new Date(a.createdAt);
+        .then(res => {
+          const sortedData = res.data.sort((a: { createdAt: string }, b: { createdAt: string }) => {
+            return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
           });
           setAllPosts(sortedData);
           setVisiblePosts(sortedData.slice(0, 10));
         })
-        .catch((error) => console.error('Error:', error));
+        .catch(error => console.error('Error:', error));
     } else {
       getAlltypePosts(props.type) //게시판 별 게시글 가져오기
-        .then((res) => {
-          const sortedData = res.data.sort((a, b) => {
-            return new Date(b.createdAt) - new Date(a.createdAt);
+        .then(res => {
+          const sortedData = res.data.sort((a: { createdAt: string }, b: { createdAt: string }) => {
+            return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
           });
           setAllPosts(sortedData);
           setVisiblePosts(sortedData.slice(0, 10));
         })
-        .catch((error) => console.error('Error:', error));
+        .catch(error => console.error('Error:', error));
     }
   }, [props.type]);
 
-
   useEffect(() => {
-    const handleIntersect = (entries) => {
+    const handleIntersect = (entries: IntersectionObserverEntry[]) => {
       if (entries[0].isIntersecting) {
         setLoading(true);
         setTimeout(() => {
@@ -45,43 +45,38 @@ const PostList = (props) => {
           const newVisiblePosts = [...visiblePosts, ...allPosts.slice(endVisibleIndex, endVisibleIndex + 10)];
           setVisiblePosts(newVisiblePosts);
           setLoading(false);
-        }, );
+        }, 0);
       }
     };
-  
+
     const observer = new IntersectionObserver(handleIntersect, {
       root: null,
       rootMargin: '0px',
       threshold: 0.1,
     });
-  
+
     if (intersectionRef.current) {
       observer.observe(intersectionRef.current);
     }
-  
+
     return () => {
       observer.disconnect();
     };
   }, [allPosts, visiblePosts]);
-  
+
   return (
     <div className="post_list_container">
-      {visiblePosts.map((post) => (
+      {visiblePosts.map((post: Post) => (
         <div className="post_item" key={post.postId}>
           <div className="post_header">
-          <Link
-            to={post.type === 'free' ? `/free/${post.postId}/${post.userId}/${post.voteId}` : `/auth/${post.postId}/${post.userId}`}
-            className="post_title"
-          >
-            {post.title}
-          </Link>
-            <div className="post_date">
-              {new Date(post.createdAt).toLocaleDateString()}
-            </div>
+            <Link
+              to={post.type === 'free' ? `/free/${post.postId}/${post.userId}` : `/auth/${post.postId}/${post.userId}`}
+              className="post_title">
+              {post.title}
+            </Link>
+            <div className="post_date">{new Date(post.createdAt).toLocaleDateString()}</div>
           </div>
-          <div className="post_content">
-          {post.body.length > 90 ? `${post.body.slice(0, 90)}...` : post.body}
-          </div>
+          <div className="post_content">{post.body.length > 90 ? `${post.body.slice(0, 90)}...` : post.body}</div>
         </div>
       ))}
       {loading && <div>Loading...</div>}

--- a/client/src/pages/AllBoardPage.jsx
+++ b/client/src/pages/AllBoardPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../styles/Button.css';
-import PostList from '../components/PostList.jsx';
+import PostList from '../components/PostList.tsx';
 import NavBar from '../components/NavBar.tsx';
 
 const AllBoardPage = () => {

--- a/client/src/pages/AuthBoardPage.jsx
+++ b/client/src/pages/AuthBoardPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../styles/Button.css';
-import '../components/PostList.jsx';
+import '../components/PostList.tsx';
 import AuthPostList from '../components/AuthPostList.jsx';
 import NavBar from '../components/NavBar.tsx';
 

--- a/client/src/pages/EnvBoardPage.jsx
+++ b/client/src/pages/EnvBoardPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../styles/Button.css';
-import '../components/PostList.jsx';
+import '../components/PostList.tsx';
 import EnvPostList from '../components/EnvPostList.jsx';
 import NavBar from '../components/NavBar.tsx';
 

--- a/client/src/pages/FreeBoardPage.jsx
+++ b/client/src/pages/FreeBoardPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../styles/Button.css';
-import PostList from '../components/PostList.jsx';
+import PostList from '../components/PostList.tsx';
 import NavBar from '../components/NavBar.tsx';
 
 const FreeBoardPage = () => {

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -1,0 +1,13 @@
+export interface Post {
+  createdAt: string;
+  postId: number;
+  type: string;
+  title: string;
+  userId: number;
+  body: string;
+  open: boolean;
+}
+
+export interface PostListProps {
+  type: string;
+}


### PR DESCRIPTION
## 작업분류
- [ ]  버그 수정
- [ ]  신규 기능
- [x]  리팩토링
- [ ]  스타일
- [ ]  코드포매팅

## 작업개요
- 타입스크립트 인터페이스 분리
- PostList.tsx로 리팩토링

## 작업 상세 내용
- 인터페이스 분리
types/types.ts 파일에 모든 인터페이스를 export 합니다.
```typescript
export interface Post {
  createdAt: string;
  postId: number;
  type: string;
  title: string;
  userId: number;
  body: string;
  open: boolean;
}

export interface PostListProps {
  type: string;
}
```

불러들일 때는 api 모듈을 호출했던 것과 마찬가지로 진행합니다.
`import { Post, PostListProps } from '../types/types';`

장점은 같은 인터페이스를 재사용 할 수 있으며 한 곳에서 모든 인터페이스를 관리하여 수정이 용이합니다.
